### PR TITLE
Add F, Zfh extensions

### DIFF
--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(vector_add_rvv vector_add_rvv.cpp)
 target_link_libraries(vector_add_rvv xbyak_riscv)
 
+add_executable(vector_add_rvv_f32 vector_add_rvv_f32.cpp)
+target_link_libraries(vector_add_rvv_f32 xbyak_riscv)
+
 add_executable(add add.cpp)
 target_link_libraries(add xbyak_riscv)
 

--- a/sample/vector_add_rvv_f32.cpp
+++ b/sample/vector_add_rvv_f32.cpp
@@ -1,0 +1,185 @@
+/******************************************************************************
+* Copyright (C), 2023, KNS Group LLC (YADRO)
+*
+* Licensed under the 3-Clause BSD License
+* You may obtain a copy of the License at https://opensource.org/license/bsd-3-clause/
+*******************************************************************************/
+
+#include <xbyak_riscv/xbyak_riscv.hpp>
+#include <xbyak_riscv/xbyak_riscv_util.hpp>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <random>
+
+using namespace Xbyak_riscv;
+
+std::vector<float> generateRandomF32Vector(size_t size, float minValue=-1000.0, float maxValue=1000.0) {
+    std::random_device random_device;
+    std::mt19937 random_engine(random_device());
+    std::uniform_real_distribution<float> udistr(minValue, maxValue);
+
+    std::vector<float> result(size);
+    std::generate(result.begin(), result.end(), [&]() { return udistr(random_engine); });
+    return result;
+}
+
+bool areF32VectorsEqual(const std::vector<float>& lhs, const std::vector<float>& rhs) {
+    if (lhs.size() != rhs.size()) {
+        std::cout << "Vectors are of different sizes";
+        return false;
+    }
+
+    const auto mismatchPair = std::mismatch(lhs.cbegin(), lhs.cend(), rhs.cbegin());
+    if (mismatchPair.first != lhs.cend()) {
+        std::cout << "Incorrect result:\n";
+        std::cout << "Expected " << *mismatchPair.first << ", but got "<< *mismatchPair.second << "!\n"; 
+        return false;
+    }
+
+    return true;
+}
+
+void vecSumReference(float* result, const float* lhs, const float* rhs, int size) {
+    for (int i = 0; i < size; ++i) {
+        result[i] = lhs[i] + rhs[i];
+    }
+}
+
+struct vecSumJITGenerator : public CodeGenerator {
+    bool useRVV = false;
+
+    vecSumJITGenerator() {
+        CPU cpu;
+        useRVV = cpu.hasExtension(RISCVExtension::V);
+        generate();
+    }
+
+    void generate() {
+        // Function arguments:
+        // a0 = float* result
+        // a1 = const float* lhs
+        // a2 = const float* rhs
+        // a3 = int size
+
+        if (useRVV) {
+            // V extension is available on this RISC-V CPU -
+            // generate the addition function using vector instructions
+            std::cout << "Generating addition function with RVV ..." << std::endl;
+
+            // Used temp registers:
+            // t0 = cycleLength
+            // t1 = Processed elements counter
+            // t2 = size - cycleLength
+            // t3 = cycleLength elements in bytes
+            // t4 = (size - cycleLength) elements in bytes
+
+            // Save a0, a1, a2 pointers
+            add(a5, x0, a0);
+            add(a6, x0, a1);
+            add(a7, x0, a2);
+
+            vsetvli(t0, a3, SEW::e32, LMUL::m8);
+            sub(t2, a3, t0);  // set t2 to (size - cycleLength)
+            slli(t3, t0, 2);  // set t3 to cycleLength elements in bytes
+
+            //
+            //  Main loop processing cycleLength elements per iteration
+            //
+
+            // Initialize processed elements counter
+            add(t1, zero, zero);
+
+            Label vvaddfloat32;
+            L(vvaddfloat32);
+            add(t1, t1, t0);
+            // Load VL elements from lhs and rhs
+            vle32_v(v0, a1);
+            vle32_v(v8, a2);
+            // Sum the elements, store result to a0 address
+            vfadd_vv(v16, v0, v8);
+            vse32_v(v16, a0);
+            // Increase the pointers by (cycleLength * 4) bytes
+            add(a0, a0, t3);
+            add(a1, a1, t3);
+            add(a2, a2, t3);
+            // Loop back if less than (size - cycleLength) elements has been processed
+            blt(t1, t2, vvaddfloat32);
+
+            //
+            //  Tile processing for the last cycleLength elements
+            //
+
+            // Restore lhs, rhs, result pointers and set
+            // them to [size - cycleLength]-th element
+            slli(t4, t2, 2);
+            add(a0, x0, a5);
+            add(a0, a0, t4);
+            add(a1, x0, a6);
+            add(a1, a1, t4);
+            add(a2, x0, a7);
+            add(a2, a2, t4);
+
+            // Read the last cycleLength elements from lhs and rhs
+            vle32_v(v0, a1);
+            vle32_v(v8, a2);
+            // Sum the elements, store result to a0 address
+            vfadd_vv(v16, v0, v8);
+            vse32_v(v16, a0);
+        } else {
+            // V extension is not available on the current RISC-V CPU -
+            // generate the addition function using only scalar instructions
+            std::cout << "Generating addition function without RVV ..." << std::endl;
+
+            // Initialize processed elements counter
+            add(t4, x0, x0);
+
+            Label vvaddfloat32;
+            L(vvaddfloat32);
+            // Load values from lhs and rhs, sum and store to result
+            flw(f10, 0, a1);
+            flw(f11, 0, a2);
+            fadd_s(f12, f10, f11);
+            fsw(f12, 0, a0);
+            // Move pointers, increase counter
+            addi(a0, a0, 4);
+            addi(a1, a1, 4);
+            addi(a2, a2, 4);
+            addi(t4, t4, 1);
+            // Check loop condition
+            blt(t4, a3, vvaddfloat32);
+        }
+
+        ret();
+    }
+};
+
+int main() {
+	std::cout << "Comparing reference implementation with JIT code." << std::endl;
+
+	// generate JIT code
+	vecSumJITGenerator jitKernel;
+	jitKernel.ready();
+	const auto vecSumJIT = jitKernel.getCode<void (*)(float*, const float*, const float*, int)>();
+
+	const int testSizes[] = {1, 4, 8, 10, 32, 67, 127, 129, 2535, 3546, 10000};
+	for (auto arrSize : testSizes) {
+		std::cout << "running a test for size " << arrSize << std::endl;
+		// generate two random vectors
+		std::vector<float> lhs = generateRandomF32Vector(arrSize);
+		std::vector<float> rhs = generateRandomF32Vector(arrSize);
+
+		// sum the vectors with the reference implementation
+		std::vector<float> reference(arrSize);
+		vecSumReference(reference.data(), lhs.data(), rhs.data(), arrSize);
+
+		// sum the vectors with the generated JIT function
+		std::vector<float> jitResult(arrSize);
+		vecSumJIT(jitResult.data(), lhs.data(), rhs.data(), arrSize);
+
+		// compare results
+		assert(areF32VectorsEqual(reference, jitResult));
+	}
+
+	std::cout << "tests passed!" << std::endl;
+}

--- a/xbyak_riscv/xbyak_riscv.hpp
+++ b/xbyak_riscv/xbyak_riscv.hpp
@@ -867,6 +867,10 @@ struct Bit {
 		: v(static_cast<uint32_t>(csr))
 	{
 	}
+	Bit(const RM& rm)
+		: v(static_cast<uint32_t>(rm))
+	{
+	}
 };
 
 } // local
@@ -1053,6 +1057,56 @@ private:
 			func3 and opcode must be encoded in the baseValue
 		*/
 		uint32_t v = (csr.v<<20) | (rs1_uimm.v<<15) | (rd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opLoadFP(Bit32 baseValue, Bit12 imm, Bit5 rs1, Bit5 rd)
+	{
+		/*
+			31 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			imm[11:0]     rs1       width       rd      opcode
+
+			width and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (imm.v<<20) | (rs1.v<<15) | (rd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opStoreFP(Bit32 baseValue, Bit12 imm, Bit5 rs2, Bit5 rs1)
+	{
+		/*
+			31 .. 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			imm[11:5]     rs2        rs1       width    imm[4:0]   opcode
+
+			width and opcode must be encoded in the baseValue
+		*/
+		uint32_t imm_11_5 = imm.v & (local::mask(7)<<5);
+		uint32_t imm_4_0 = imm.v & local::mask(5);
+		uint32_t v = (imm_11_5<<25) | (rs2.v<<20) | (rs1.v<<15) | (imm_4_0<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opFP(Bit32 baseValue, Bit5 rs2, Bit5 rs1, Bit3 rm, Bit5 rd)
+	{
+		/*
+			31 .. 27 | 26 .. 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			  func5       fmt        rs2        rs1        rm         rd      opcode
+
+			func5, fmt, and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (rs2.v<<20) | (rs1.v<<15) | (rm.v<<12) | (rd.v<<7);
+		v |= baseValue.v; // force-encode base value
+		append4B(v);
+	}
+	void opR4(Bit32 baseValue, Bit5 rs3, Bit5 rs2, Bit5 rs1, Bit3 rm, Bit5 rd)
+	{
+		/*
+			31 .. 27 | 26 .. 25 | 24 .. 20 | 19 .. 15 | 14 .. 12 | 11 .. 7 | 6 .. 0
+			   rs3        fmt        rs2        rs1        rm         rd      opcode
+
+			fmt and opcode must be encoded in the baseValue
+		*/
+		uint32_t v = (rs3.v<<27) | (rs2.v<<20) | (rs1.v<<15) | (rm.v<<12) | (rd.v<<7);
 		v |= baseValue.v; // force-encode base value
 		append4B(v);
 	}

--- a/xbyak_riscv/xbyak_riscv_csr.hpp
+++ b/xbyak_riscv/xbyak_riscv_csr.hpp
@@ -20,6 +20,7 @@ enum class CSR : uint32_t {
     vlenb  = 0xC22, // VLEN/8 (vector register length in bytes)
 };
 
+
 // Selected Element Width
 enum class SEW : uint32_t {
     e8  = 0x0,
@@ -84,6 +85,16 @@ enum class WidthEncoding : uint32_t {
 enum class VM : uint32_t {
     unmasked = 1,
     masked = 0
+};
+
+enum class RM : uint32_t {
+    RNE = 0x0, // Round to Nearest, ties to Even
+    RTZ = 0x1, // Round towards Zero
+    RDN = 0x2, // Round Down (towards −∞)
+    RUP = 0x3, // Round Up (towards +∞)
+    RMM = 0x4, // Round to Nearest, ties to Max Magnitude
+    DYN = 0x7  // In instruction’s rm field, selects dynamic rounding mode;
+               // In Rounding Mode register, reserved.
 };
 
 } // Xbyak_riscv

--- a/xbyak_riscv/xbyak_riscv_mnemonic.hpp
+++ b/xbyak_riscv/xbyak_riscv_mnemonic.hpp
@@ -112,6 +112,73 @@ void csrrc(const Reg& rd, CSR csr, const Reg& rs1) { opCSR(0x3073, csr, rs1, rd)
 void csrrwi(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x5073, csr, imm, rd); }
 void csrrsi(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x6073, csr, imm, rd); }
 void csrrci(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x7073, csr, imm, rd); }
+void fadd_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::DYN) { opFP(0x53, rs2, rs1, rm, rd); }
+void fclass_s(const Reg& rd, const FReg& rs1) { opFP(0xe0001053, 0, rs1, 0, rd); }
+void fcvt_s_w(const FReg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0xd0000053, 0, rs1, rm, rd); }
+void fcvt_s_wu(const FReg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0xd0100053, 0, rs1, rm, rd); }
+void fcvt_w_s(const Reg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0xc0000053, 0, rs1, rm, rd); }
+void fcvt_wu_s(const Reg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0xc0100053, 0, rs1, rm, rd); }
+void fdiv_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::DYN) { opFP(0x18000053, rs2, rs1, rm, rd); }
+void feq_s(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa0002053, rs2, rs1, 0, rd); }
+void fle_s(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa0000053, rs2, rs1, 0, rd); }
+void flt_s(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa0001053, rs2, rs1, 0, rd); }
+void fmax_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x28001053, rs2, rs1, 0, rd); }
+void fmin_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x28000053, rs2, rs1, 0, rd); }
+void fmul_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::DYN) { opFP(0x10000053, rs2, rs1, rm, rd); }
+void fmv_w_x(const FReg& rd, const Reg& rs1) { opFP(0xf0000053, 0, rs1, 0, rd); }
+void fmv_x_w(const Reg& rd, const FReg& rs1) { opFP(0xe0000053, 0, rs1, 0, rd); }
+void fsgnj_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x20000053, rs2, rs1, 0, rd); }
+void fsgnjn_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x20001053, rs2, rs1, 0, rd); }
+void fsgnjx_s(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x20002053, rs2, rs1, 0, rd); }
+void fsqrt_s(const FReg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0x58000053, 0, rs1, rm, rd); }
+void fsub_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::DYN) { opFP(0x8000053, rs2, rs1, rm, rd); }
+void fcvt_l_s(const Reg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0xc0200053, 0, rs1, rm, rd); }
+void fcvt_lu_s(const Reg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0xc0300053, 0, rs1, rm, rd); }
+void fcvt_s_l(const FReg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0xd0200053, 0, rs1, rm, rd); }
+void fcvt_s_lu(const FReg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0xd0300053, 0, rs1, rm, rd); }
+void fadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::DYN) { opFP(0x4000053, rs2, rs1, rm, rd); }
+void fclass_h(const Reg& rd, const FReg& rs1) { opFP(0xe4001053, 0, rs1, 0, rd); }
+void fcvt_h_s(const Reg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0x44000053, 0, rs1, rm, rd); }
+void fcvt_h_w(const FReg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0xd4000053, 0, rs1, rm, rd); }
+void fcvt_h_wu(const FReg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0xd4100053, 0, rs1, rm, rd); }
+void fcvt_s_h(const Reg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0x40200053, 0, rs1, rm, rd); }
+void fcvt_w_h(const Reg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0xc4000053, 0, rs1, rm, rd); }
+void fcvt_wu_h(const Reg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0xc4100053, 0, rs1, rm, rd); }
+void fdiv_h(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::DYN) { opFP(0x1c000053, rs2, rs1, rm, rd); }
+void feq_h(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa4002053, rs2, rs1, 0, rd); }
+void fle_h(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa4000053, rs2, rs1, 0, rd); }
+void flt_h(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa4001053, rs2, rs1, 0, rd); }
+void fmax_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x2c001053, rs2, rs1, 0, rd); }
+void fmin_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x2c000053, rs2, rs1, 0, rd); }
+void fmul_h(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::DYN) { opFP(0x14000053, rs2, rs1, rm, rd); }
+void fmv_h_x(const FReg& rd, const Reg& rs1) { opFP(0xf4000053, 0, rs1, 0, rd); }
+void fmv_x_h(const Reg& rd, const FReg& rs1) { opFP(0xe4000053, 0, rs1, 0, rd); }
+void fsgnj_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x24000053, rs2, rs1, 0, rd); }
+void fsgnjn_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x24001053, rs2, rs1, 0, rd); }
+void fsgnjx_h(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x24002053, rs2, rs1, 0, rd); }
+void fsqrt_h(const FReg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0x5c000053, 0, rs1, rm, rd); }
+void fsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::DYN) { opFP(0xc000053, rs2, rs1, rm, rd); }
+void fcvt_h_l(const FReg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0xd4200053, 0, rs1, rm, rd); }
+void fcvt_h_lu(const FReg& rd, const Reg& rs1, RM rm=RM::DYN) { opFP(0xd4300053, 0, rs1, rm, rd); }
+void fcvt_l_h(const Reg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0xc4200053, 0, rs1, rm, rd); }
+void fcvt_lu_h(const Reg& rd, const FReg& rs1, RM rm=RM::DYN) { opFP(0xc4300053, 0, rs1, rm, rd); }
+
+void fmadd_s(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::DYN) { opR4(0x43, rs3, rs2, rs1, rm, rd); }
+void fmsub_s(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::DYN) { opR4(0x47, rs3, rs2, rs1, rm, rd); }
+void fnmsub_s(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::DYN) { opR4(0x4b, rs3, rs2, rs1, rm, rd); }
+void fnmadd_s(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::DYN) { opR4(0x4f, rs3, rs2, rs1, rm, rd); }
+
+void fmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::DYN) { opR4(0x4000043, rs3, rs2, rs1, rm, rd); }
+void fmsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::DYN) { opR4(0x4000047, rs3, rs2, rs1, rm, rd); }
+void fnmsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::DYN) { opR4(0x400004b, rs3, rs2, rs1, rm, rd); }
+void fnmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::DYN) { opR4(0x400004f, rs3, rs2, rs1, rm, rd); }
+
+
+void flw(const FReg& rd, int32_t imm12, const Reg& rs1) { opLoadFP(0x2007, imm12, rs1, rd); }
+void fsw(const FReg& rs2, int32_t imm12, const Reg& rs1) { opStoreFP(0x2027, imm12, rs2, rs1); }
+void flh(const FReg& rd, int32_t imm12, const Reg& rs1) { opLoadFP(0x1007, imm12, rs1, rd); }
+void fsh(const FReg& rs2, int32_t imm12, const Reg& rs1) { opStoreFP(0x1027, imm12, rs2, rs1); }
+
 
 void nop() { if (supportRVC_) { append2B(0x0001); return;} addi(x0, x0, 0); }
 void li(const Reg& rd, int imm) { addi(rd, x0, imm); }


### PR DESCRIPTION
Hello, @herumi!

This PR adds instructions from RV32, RV64, RV32_Zfh, RV64_Zfh extensions.
There is also a sample with RVV/scalar floating-point vectors addition.

We are looking forward to hear your opinion on this.
Thanks