### PR TITLE
Add f[s,l][d,q] instructions

### DIFF
--- a/gen/gen.py
+++ b/gen/gen.py
@@ -344,6 +344,10 @@ void fnmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3,
 
 # encode LOAD-FP, STORE-FP instructions
 print('''
+void flq(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x4007, imm12, rs1, rd); }
+void fsq(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x4027, imm12, rs2, rs1); }
+void fld(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x3007, imm12, rs1, rd); }
+void fsd(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x3027, imm12, rs2, rs1); }
 void flw(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x2007, imm12, rs1, rd); }
 void fsw(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x2027, imm12, rs2, rs1); }
 void flh(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x1007, imm12, rs1, rd); }

--- a/xbyak_riscv/xbyak_riscv_mnemonic.hpp
+++ b/xbyak_riscv/xbyak_riscv_mnemonic.hpp
@@ -174,6 +174,10 @@ void fnmsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3,
 void fnmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x400004f, rs3, rs2, rs1, rm, rd); }
 
 
+void flq(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x4007, imm12, rs1, rd); }
+void fsq(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x4027, imm12, rs2, rs1); }
+void fld(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x3007, imm12, rs1, rd); }
+void fsd(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x3027, imm12, rs2, rs1); }
 void flw(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x2007, imm12, rs1, rd); }
 void fsw(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x2027, imm12, rs2, rs1); }
 void flh(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x1007, imm12, rs1, rd); }


### PR DESCRIPTION
Hello, @herumi!

In this PR I would like to add f[s,l][d,q] instructions to xbyak list.
![fsdqd](https://github.com/herumi/xbyak_riscv/assets/138121190/47d4d840-82a9-4bba-9862-f58e5566a16c)

Waiting for your opinion.
Thanks for contributing in RISC-V!