### PR TITLE
Singleton for CPU info class

### DIFF
--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -13,7 +13,7 @@ using namespace Xbyak_riscv;
 
 int main()
 {
-    CPU cpu;
+    const auto& cpu = CPU::getInstance();
 
     std::cout << "Number of RISC-V CPU cores: " << cpu.getNumCores() << std::endl;
     std::cout << "XLEN:  " << cpu.getXlenb() << std::endl;

--- a/sample/vector_add_rvv.cpp
+++ b/sample/vector_add_rvv.cpp
@@ -50,7 +50,7 @@ struct vecSumJITGenerator : public CodeGenerator {
     bool useRVV = false;
 
     vecSumJITGenerator() {
-        CPU cpu;
+        const auto& cpu = CPU::getInstance();
         useRVV = cpu.hasExtension(RISCVExtension::V);
         generate();
     }

--- a/sample/vector_add_rvv_f32.cpp
+++ b/sample/vector_add_rvv_f32.cpp
@@ -50,7 +50,7 @@ struct vecSumJITGenerator : public CodeGenerator {
     bool useRVV = false;
 
     vecSumJITGenerator() {
-        CPU cpu;
+        const auto& cpu = CPU::getInstance();
         useRVV = cpu.hasExtension(RISCVExtension::V);
         generate();
     }

--- a/xbyak_riscv/xbyak_riscv_util.hpp
+++ b/xbyak_riscv/xbyak_riscv_util.hpp
@@ -74,8 +74,13 @@ struct CSRReader : public CodeGenerator {
 /**
  * Class that detects information about a RISC-V CPU.
  */
-class CPU {
+class CPU final {
 public:
+    static const CPU& getInstance() {
+        static const CPU cpu;
+        return cpu;
+    }
+
     CPU() {
 #if defined(__linux__) && defined(__riscv)
         // Set hwcapFeatures with AT_HWCAP value from


### PR DESCRIPTION
Hello @herumi, first of all let me thank you on the great work you've done. Xbyak for RISC-V is a great project for the enabling of the platform, and pretty much a lifesaver for many developers around the world. 

As a user of your project, I would like to propose a little patch.
The idea is to use common single object of CPU info class instead of creating the objects in every caller.

Thank you!