### PR TITLE
Add flenb into CPU info class

### DIFF
--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -16,8 +16,9 @@ int main()
     CPU cpu;
 
     std::cout << "Number of RISC-V CPU cores: " << cpu.getNumCores() << std::endl;
-    std::cout << "XLEN:  " << cpu.getXlenb() << std::endl;
-    std::cout << "VLENB: " <<  cpu.getVlenb() << std::endl;
+    std::cout << "XLENB: " << cpu.getXlenb() << std::endl;
+    std::cout << "VLENB: " << cpu.getVlenb() << std::endl;
+    std::cout << "FLENB: " << cpu.getFlenb() << std::endl;
     std::cout << std::endl;
 
     std::cout << "Supported RISC-V extensions:" << std::endl;

--- a/xbyak_riscv/xbyak_riscv_util.hpp
+++ b/xbyak_riscv/xbyak_riscv_util.hpp
@@ -118,6 +118,13 @@ public:
                 const auto csrReader = csrReaderGenerator.getCode<uint32_t (*)()>();
                 vlenb = csrReader();
         }
+
+        // Set flenb
+        if (hasExtension(RISCVExtension::D)) {
+            flenb = 64;
+        } else if (hasExtension(RISCVExtension::F)) {
+            flenb = 32;
+        }
     }
 
     /**
@@ -133,9 +140,13 @@ public:
         return vlenb;
     }
 
-    uint64_t getXlenb() const {
+    uint32_t getXlenb() const {
         return xlenb;
     };
+
+    uint32_t getFlenb() const {
+        return flenb;
+    }
 
     uint32_t getNumCores() const {
         return numCores;
@@ -159,6 +170,7 @@ private:
     uint32_t numCores = 0;
     uint32_t xlenb = 0;
     uint32_t vlenb = 0;
+    uint32_t flenb = 0;
 };
 
 } // Xbyak_riscv


### PR DESCRIPTION
Hello, once again @herumi. 
Thank you for having my previous patch merged. I would like to propose one more minor patch, that makes working with FP registers more confortable. 
Add possibility to receive flenb (FP registers length) from CPU info class.
Please review, and provide feedback.
Looking forward for more cooperation.