### PR TITLE
Get xlenb, flenb in bytes, not in bits

### DIFF
--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -16,9 +16,9 @@ int main()
     CPU cpu;
 
     std::cout << "Number of RISC-V CPU cores: " << cpu.getNumCores() << std::endl;
-    std::cout << "XLENB: " << cpu.getXlenb() << std::endl;
-    std::cout << "VLENB: " << cpu.getVlenb() << std::endl;
-    std::cout << "FLENB: " << cpu.getFlenb() << std::endl;
+    std::cout << "XLENB: " << cpu.getXlenb() << " bytes (" << cpu.getXlen() << " bits)" << std::endl;
+    std::cout << "VLENB: " << cpu.getVlenb() << " bytes (" << cpu.getVlen() << " bits)" << std::endl;
+    std::cout << "FLENB: " << cpu.getFlenb() << " bytes (" << cpu.getFlen() << " bits)" << std::endl;
     std::cout << std::endl;
 
     std::cout << "Supported RISC-V extensions:" << std::endl;

--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -16,9 +16,9 @@ int main()
     CPU cpu;
 
     std::cout << "Number of RISC-V CPU cores: " << cpu.getNumCores() << std::endl;
-    std::cout << "XLENB: " << cpu.getXlenb() << " bytes (" << cpu.getXlen() << " bits)" << std::endl;
-    std::cout << "VLENB: " << cpu.getVlenb() << " bytes (" << cpu.getVlen() << " bits)" << std::endl;
-    std::cout << "FLENB: " << cpu.getFlenb() << " bytes (" << cpu.getFlen() << " bits)" << std::endl;
+    std::cout << "XLENB: " << cpu.getXlenByte() << " bytes (" << cpu.getXlen() << " bits)" << std::endl;
+    std::cout << "VLENB: " << cpu.getVlenByte() << " bytes (" << cpu.getVlen() << " bits)" << std::endl;
+    std::cout << "FLENB: " << cpu.getFlenByte() << " bytes (" << cpu.getFlen() << " bits)" << std::endl;
     std::cout << std::endl;
 
     std::cout << "Supported RISC-V extensions:" << std::endl;

--- a/xbyak_riscv/xbyak_riscv_util.hpp
+++ b/xbyak_riscv/xbyak_riscv_util.hpp
@@ -140,7 +140,7 @@ public:
     /**
      * Get vector register width in bytes
     */
-    uint32_t getVlenb() const {
+    uint32_t getVlenByte() const {
         return vlenb;
     }
 
@@ -154,7 +154,7 @@ public:
     /**
      * Get general purpose register width in bytes
     */
-    uint32_t getXlenb() const {
+    uint32_t getXlenByte() const {
         return xlenb;
     };
 
@@ -168,7 +168,7 @@ public:
     /**
      * Get floating-point register width in bytes
     */
-    uint32_t getFlenb() const {
+    uint32_t getFlenByte() const {
         return flenb;
     }
 


### PR DESCRIPTION
Hello, @herumi! Thank you for the long work on this project, I want to propose a small fix.

According to the RISC-V specification:

- **VLENB** is `VLEN/8 (vector register length in bytes)` 
- **XLEN** is `the width of an integer register in bits (either 32 or 64).`

I.e. this `b` postfix is apparently used to mark length in **bytes**, so the `getXlenb` and `getFlenb` functions are currently misaligned with the specification, since they should return length in bytes.

I propose the following alignment.
```
uint32_t getVlenb() const; // Get vector register width in bytes
uint32_t getVlen() const;  // Get vector register width in bits

uint32_t getXlenb() const; // Get general purpose register width in bytes
uint32_t getXlen() const;  // Get general purpose register width in bits

uint32_t getFlenb() const; // Get floating-point register width in bytes
uint32_t getFlen() const;  // Get floating-point register width in bits
```