### PR TITLE
Fix for li pseudo-instruction, cases with big imm values

### DIFF
--- a/xbyak_riscv/xbyak_riscv_mnemonic.hpp
+++ b/xbyak_riscv/xbyak_riscv_mnemonic.hpp
@@ -184,8 +184,17 @@ void flh(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x1007, i
 void fsh(const FReg& rs2, const Reg& rs1, int32_t imm12 = 0) { opStoreFP(0x1027, imm12, rs2, rs1); }
 
 
-void nop() { if (supportRVC_) { append2B(0x0001); return;} addi(x0, x0, 0); }
-void li(const Reg& rd, int imm) { addi(rd, x0, imm); }
+void nop() { if (supportRVC_) { append2B(0x0001); return; } addi(x0, x0, 0); }
+void li(const Reg& rd, int imm) {
+	if (imm >= -2048 && imm <= 2047) {
+		addi(rd, x0, imm);
+	} else {
+		const auto hi20bits = (imm >> 11) & 1 ? ((imm >> 12) & 0xfffff) + 1 : imm >> 12 & 0xfffff; // Respect LSB for addi here via "+1"
+		const auto low12bits = (imm >> 11) & 1 ? (imm & 0xfff) | 0xfffff000 : imm & 0xfff;         // Respect LSB for addi, propagate the sign
+		lui(rd, hi20bits);
+		addi(rd, rd, low12bits);
+	}
+}
 void mv(const Reg& rd, const Reg& rs) { addi(rd, rs, 0); }
 void not_(const Reg& rd, const Reg& rs) { xori(rd, rs, -1); }
 void neg(const Reg& rd, const Reg& rs) { sub(rd, x0, rs); }


### PR DESCRIPTION
Hello, @herumi!
This small PR fixes the li pseudo-instruction in cases with big immediate values.
Thank you in advance.