### PR TITLE
Added pseudoinstruction vfneg_v and vfabs_v support

### DIFF
--- a/gen/gen_v.py
+++ b/gen/gen_v.py
@@ -349,6 +349,12 @@ void vmfgt_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmask
 
 void vmfge_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { vmfle_vv(vd, vs2, vs1, vm); }''')
 
+    # generate sign-related pseudoinstructions
+    print('''
+void vfabs_v(const VReg& vd, const VReg& vs, VM vm=VM::unmasked) { vfsgnjx_vv(vd, vs, vs, vm); }
+
+void vfneg_v(const VReg& vd, const VReg& vs, VM vm=VM::unmasked) { vfsgnjn_vv(vd, vs, vs, vm); }''')
+
 def main():
   copyright.put()
   generate_RVV()

--- a/xbyak_riscv/xbyak_riscv_v.hpp
+++ b/xbyak_riscv/xbyak_riscv_v.hpp
@@ -766,7 +766,10 @@ void vmset_m(const VReg& vd) { vmxnor_mm(vd, vd, vd); }
 // Invert bits
 void vmnot_m(const VReg& vd, const VReg& vs) { vmnand_mm(vd, vs, vs); }
 
-
+// vector compare pseudoinstructions
 void vmfgt_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { vmflt_vv(vd, vs2, vs1, vm); }
-
 void vmfge_vv(const VReg& vd, const VReg& vs1, const VReg& vs2, VM vm=VM::unmasked) { vmfle_vv(vd, vs2, vs1, vm); }
+
+// sign-related pseudoinstructions
+void vfabs_v(const VReg& vd, const VReg& vs, VM vm=VM::unmasked) { vfsgnjx_vv(vd, vs, vs, vm); }
+void vfneg_v(const VReg& vd, const VReg& vs, VM vm=VM::unmasked) { vfsgnjn_vv(vd, vs, vs, vm); }


### PR DESCRIPTION
Hi @herumi!

If you don't mind, I prepared the PR with pseudo instructions `vfabs_v` (absolute value) and `vfneg_v` (negative). I used these instructions in my work and decided that it'd be useful if they were in the `xbyak_riscv` repository.

Thank you in advance!