### PR TITLE
Added Floating-Point CSRs

### DIFF
--- a/xbyak_riscv/xbyak_riscv_csr.hpp
+++ b/xbyak_riscv/xbyak_riscv_csr.hpp
@@ -10,6 +10,10 @@ namespace Xbyak_riscv {
 
 // Control and Status Register
 enum class CSR : uint32_t {
+    // FP CSRs
+    fflags = 0x001, // Floating-Point Accrued Exceptions
+    frm    = 0x002, // Floating-Point Dynamic Rounding Mode
+    fcsr   = 0x003, // Floating-Point Control and Status register
     // vector CSRs
     vstart = 0x008, // Vector start position
     vxsat  = 0x009, // Fixed-Point Saturate Flag
@@ -95,6 +99,14 @@ enum class RM : uint32_t {
     rmm = 0x4, // Round to Nearest, ties to Max Magnitude
     dyn = 0x7  // In instruction’s rm field, selects dynamic rounding mode;
                // In Rounding Mode register, reserved.
+};
+
+enum class FFlags : uint32_t {
+    NV = 0x01, // Invalid Operation 
+    DZ = 0x02, // Divide by Zero
+    OF = 0x04, // Overflow
+    UF = 0x08, // Underflow
+    NX = 0x10  // Inexact
 };
 
 } // Xbyak_riscv


### PR DESCRIPTION
I'm working with floating-point vector instructions and for some instructions I need to set rounding mode (conversion instructions):

[10.1. Vector Arithmetic Instruction encoding](https://github.com/riscvarchive/riscv-v-spec/releases/tag/v1.0)
> All standard vector floating-point arithmetic operations follow the IEEE-754/2008 standard. All vector floating-point
operations use the dynamic rounding mode in the frm register.

This FP RM is missed here. And I decided to add it with other FP control and status registers (CSRs).

@herumi could you take a look please? Let me know about any additional changes. Thank you in advance 😃 

