### PR TITLE
Feature: Add riscv_hwprobe support and Z-extension detection (Zvfh, Zvbb, Zvbc, Zvkg)

### DIFF
--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -29,6 +29,11 @@ int main()
     std::cout << "Has D: " <<  cpu.hasExtension(RISCVExtension::D) << std::endl;
     std::cout << "Has C: " <<  cpu.hasExtension(RISCVExtension::C) << std::endl;
     std::cout << "Has V: " <<  cpu.hasExtension(RISCVExtension::V) << std::endl;
+    
+    std::cout << "Has Zvfh: " <<  cpu.hasExtension(RISCVExtension::Zvfh) << std::endl;
+    std::cout << "Has Zvbb: " <<  cpu.hasExtension(RISCVExtension::Zvbb) << std::endl;
+    std::cout << "Has Zvbc: " <<  cpu.hasExtension(RISCVExtension::Zvbc) << std::endl;
+    std::cout << "Has Zvkg: " <<  cpu.hasExtension(RISCVExtension::Zvkg) << std::endl;
     std::cout << std::endl;
 
     std::cout << "Cache info:" << std::endl;

--- a/xbyak_riscv/xbyak_riscv.hpp
+++ b/xbyak_riscv/xbyak_riscv.hpp
@@ -155,10 +155,10 @@ inline void SetError(int err) {
 inline void ClearError() {
 	local::GetErrorRef() = 0;
 }
-inline int GetError() { return Xbyak::local::GetErrorRef(); }
+inline int GetError() { return Xbyak_riscv::local::GetErrorRef(); }
 
-#define XBYAK_RISCV_THROW(err) { Xbyak::local::SetError(err); return; }
-#define XBYAK_RISCV_THROW_RET(err, r) { Xbyak::local::SetError(err); return r; }
+#define XBYAK_RISCV_THROW(err) { Xbyak_riscv::local::SetError(err); return; }
+#define XBYAK_RISCV_THROW_RET(err, r) { Xbyak_riscv::local::SetError(err); return r; }
 
 #else
 class Error : public std::exception {

--- a/xbyak_riscv/xbyak_riscv_util.hpp
+++ b/xbyak_riscv/xbyak_riscv_util.hpp
@@ -10,6 +10,10 @@
 #include <climits>
 #include <cstddef>
 #include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cstring>
 #include "xbyak_riscv_csr.hpp"
 #include "xbyak_riscv.hpp"
 
@@ -18,11 +22,13 @@
 #include <sys/prctl.h>
 #include <sys/utsname.h>
 #include <asm/hwcap.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 #endif
 
 namespace Xbyak_riscv {
 
+// Legacy HWCAP constants
 #ifndef COMPAT_HWCAP_ISA_I
 #define COMPAT_HWCAP_ISA_I  (1U << ('I' - 'A'))
 #endif
@@ -51,14 +57,58 @@ namespace Xbyak_riscv {
 #define COMPAT_HWCAP_ISA_V  (1U << ('V' - 'A'))
 #endif
 
+#if defined(__linux__) && defined(__riscv)
+// Definitions for riscv_hwprobe (Linux 6.4+)
+#ifndef __NR_riscv_hwprobe
+#define __NR_riscv_hwprobe 258
+#endif
+
+#ifndef RISCV_HWPROBE_KEY_IMA_EXT_0
+#define RISCV_HWPROBE_KEY_IMA_EXT_0 4
+#endif
+
+#ifndef RISCV_HWPROBE_IMA_V
+#define RISCV_HWPROBE_IMA_V (1ULL << 2)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZVBB
+#define RISCV_HWPROBE_EXT_ZVBB (1ULL << 17)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZVBC
+#define RISCV_HWPROBE_EXT_ZVBC (1ULL << 18)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZVKG
+#define RISCV_HWPROBE_EXT_ZVKG (1ULL << 20)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZVFH
+#define RISCV_HWPROBE_EXT_ZVFH (1ULL << 30)
+#endif
+
+struct riscv_hwprobe {
+    int64_t key;
+    uint64_t value;
+};
+#endif
+
 enum class RISCVExtension : uint64_t {
+    // 0-25: Legacy single-letter map (matches HWCAP for convenience)
     I = COMPAT_HWCAP_ISA_I,
     M = COMPAT_HWCAP_ISA_M,
     A = COMPAT_HWCAP_ISA_A,
     F = COMPAT_HWCAP_ISA_F,
     D = COMPAT_HWCAP_ISA_D,
     C = COMPAT_HWCAP_ISA_C,
-    V = COMPAT_HWCAP_ISA_V
+    V = COMPAT_HWCAP_ISA_V,
+
+    // 26+: Extended Z-extensions
+    // Adding new extensions here is safe and conflict-free
+    Zvfh = 1ULL << 26,
+    Zvbb = 1ULL << 27,
+    Zvbc = 1ULL << 28,
+    Zvkg = 1ULL << 29
 };
 
 template <CSR csr>
@@ -83,6 +133,9 @@ public:
     }
 
     CPU() {
+        hwcapFeatures = 0;
+        xlen = sizeof(void*) * 8; // Fallback if sysconf fails
+        
 #if defined(__linux__) && defined(__riscv)
         // Set hwcapFeatures with AT_HWCAP value from
         // the Linux auxiliary vector to check for base extensions support.
@@ -96,9 +149,34 @@ public:
             COMPAT_HWCAP_ISA_V
         );
 
+        // Try to use riscv_hwprobe to detect Z-extensions
+        struct riscv_hwprobe requests[] = {
+            {RISCV_HWPROBE_KEY_IMA_EXT_0, 0}
+        };
+        
+        int ret = syscall(__NR_riscv_hwprobe, &requests, sizeof(requests) / sizeof(requests[0]), 0, NULL, 0);
+
+        if (ret == 0) {
+            uint64_t v = requests[0].value;
+            // Update V support from hwprobe if present
+            if (v & RISCV_HWPROBE_IMA_V) hwcapFeatures |= static_cast<uint64_t>(RISCVExtension::V);
+            
+            // Detect Z-extensions using the table
+            for (const auto& entry : getExtensionTable()) {
+                if (v & entry.hwprobe_bit) {
+                    hwcapFeatures |= static_cast<uint64_t>(entry.id);
+                }
+            }
+        } else {
+            // Fallback: If hwprobe failed (Kernel < 6.4), use procfs
+            // We only try this if the base Vector extension is present.
+            if (hasExtension(RISCVExtension::V)) {
+                detect_extensions_procfs();
+            }
+        }
+
         // Set xlen, number of cores, cache info
         xlen = sysconf(_SC_LONG_BIT);
-        numCores = sysconf(_SC_NPROCESSORS_ONLN);
         numCores = sysconf(_SC_NPROCESSORS_ONLN);
 
         dataCacheSize_[0] = sysconf(_SC_LEVEL1_DCACHE_SIZE);
@@ -189,6 +267,49 @@ private:
     uint32_t xlen = 0;
     uint32_t vlen = 0;
     uint32_t flen = 0;
+
+    /**
+     * Helper structure for extension mapping
+    */
+    struct ExtensionEntry {
+        RISCVExtension id;
+        uint64_t hwprobe_bit;  // Bit in RISCV_HWPROBE_KEY_IMA_EXT_0
+        const char* name;      // String in /proc/cpuinfo "isa" line
+    };
+
+    /**
+     * Centralized table for all supported Z-extensions
+    */
+    static const std::vector<ExtensionEntry>& getExtensionTable() {
+        static const std::vector<ExtensionEntry> table = {
+            { RISCVExtension::Zvfh, RISCV_HWPROBE_EXT_ZVFH, "_zvfh" },
+            { RISCVExtension::Zvbb, RISCV_HWPROBE_EXT_ZVBB, "_zvbb" },
+            { RISCVExtension::Zvbc, RISCV_HWPROBE_EXT_ZVBC, "_zvbc" },
+            { RISCVExtension::Zvkg, RISCV_HWPROBE_EXT_ZVKG, "_zvkg" }
+        };
+        return table;
+    }
+
+    /**
+     * Helper to detect all extensions in the table from /proc/cpuinfo
+    */
+    void detect_extensions_procfs() {
+        std::ifstream cpuinfo("/proc/cpuinfo");
+        if (!cpuinfo.is_open()) return;
+
+        std::string line;
+        while (std::getline(cpuinfo, line)) {
+            if (line.find("isa") == 0) {
+                for (const auto& entry : getExtensionTable()) {
+                    if (line.find(entry.name) != std::string::npos) {
+                        hwcapFeatures |= static_cast<uint64_t>(entry.id);
+                    }
+                }
+                // We only parse the first valid 'isa' line we find.
+                break; 
+            }
+        }
+    }
 };
 
 } // Xbyak_riscv


### PR DESCRIPTION
### Summary

According to [the RISE's guide](https://riscv-optimization-guide.riseproject.dev/#_detecting_risc_v_extensions_on_linux), this PR introduces support for the `riscv_hwprobe` system call (introduced in Linux 6.4) to detect newer RISC-V vector extensions.
These multi-letter extensions (Zvfh, Zvbb, Zvbc, and Zvkg) cannot be reliably detected by the legacy AT_HWCAP mechanism, making the use of the new riscv_hwprobe syscall essential.
It also implements a fallback mechanism for older kernels to ensure backward compatibility.

### Key Changes

  1. Primary Detection (`riscv_hwprobe`):
      * Added definitions for `riscv_hwprobe` and relevant keys.
      * The `CPU` class now prioritizes this syscall to detect `Zvfh` (FP16), `Zvbb`, `Zvbc`, and `Zvkg`.
  2. Fallback Detection (`/proc/cpuinfo`):
      * If the syscall returns `ENOSYS` (older kernels), the code falls back to standard `AT_HWCAP` for base extensions.
      * Added `detect_extensions_procfs` to parse `/proc/cpuinfo` for Z-extensions, but only if the base 'V' extension is confirmed.
  3. Bug Fix:
      * Fixed a namespace issue in `xbyak_riscv.hpp`: `Xbyak::local::GetErrorRef()` changed to `Xbyak_riscv::local::GetErrorRef()`.
  4. Sample:
      * Updated `sample/cpuinfo.cpp` to print the status of the newly supported extensions.

### Testing

Tested on a 64-core RISC-V Server (PolyOS) supporting ZVFH extension.
<details>

```
[xiazz@PolyOS-Server xbyak_riscv]$ cat /proc/cpuinfo
processor       : 0
hart            : 1
isa             : rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zba_zbb_zbc_zbs_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_sscofpmf_sstc_svinval_svnapot_svpbmt
mmu             : sv48
mvendorid       : 0x5b7
marchid         : 0x80000000090c0d00
mimpid          : 0x2047000
hart isa        : rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zba_zbb_zbc_zbs_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_sscofpmf_sstc_svinval_svnapot_svpbmt

processor       : 1
hart            : 0
isa             : rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zba_zbb_zbc_zbs_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_sscofpmf_sstc_svinval_svnapot_svpbmt
mmu             : sv48
mvendorid       : 0x5b7
marchid         : 0x80000000090c0d00
mimpid          : 0x2047000
hart isa        : rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zba_zbb_zbc_zbs_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_sscofpmf_sstc_svinval_svnapot_svpbmt
........................
```

</details>

**Scenario 1: Modern Kernel (using `riscv_hwprobe`)**

  * **Test Code Part:**
<details>

```
        if (ret == 0) {
            uint64_t v = requests[0].value;
            // Update V support from hwprobe if present
            if (v & RISCV_HWPROBE_IMA_V) hwcapFeatures |= static_cast<uint64_t>(RISCVExtension::V);
            
            // Detect Z-extensions using the table
            for (const auto& entry : getExtensionTable()) {
                if (v & entry.hwprobe_bit) {
                    hwcapFeatures |= static_cast<uint64_t>(entry.id);
                    std::cout << "[Xbyak_riscv DEBUG] Detected via hwprobe: " << entry.name << std::endl;
                }
            }
        } else {
            // 3. Fallback: If hwprobe failed (Kernel < 6.4), use procfs
            std::cout << "[Xbyak_riscv DEBUG] riscv_hwprobe syscall failed (ret=" << ret << "). Falling back to legacy AT_HWCAP/procfs path." << std::endl;
            // We only try this if the base Vector extension is present.
            if (hasExtension(RISCVExtension::V)) {
                std::cout << "[Xbyak_riscv DEBUG] Vector extension found via HWCAP. Parsing /proc/cpuinfo for sub-extensions." << std::endl;
                detect_extensions_procfs();
            }
        }
```

</details>

  * **Log:**

<details>

```
[xiazz@PolyOS-Server xbyak_riscv]$ clang++ -I. sample/cpuinfo.cpp -o cpuinfo
[xiazz@PolyOS-Server xbyak_riscv]$ ./cpuinfo 
[Xbyak_riscv DEBUG] Detected via hwprobe: _zvfh
Number of RISC-V CPU cores: 64
XLEN: 64 bits
VLEN: 128 bits
FLEN: 64 bits

Supported RISC-V extensions:
Has I: 1
Has M: 1
Has A: 1
Has F: 1
Has D: 1
Has C: 1
Has V: 1
Has Zvfh: 1
Has Zvbb: 0
Has Zvbc: 0
Has Zvkg: 0

Cache info:
L1 cache size: 65536
L1 cache line size: 64
L2 cache size: 2097152
L2 cache line size: 64
L3 cache size: 67108864
L3 cache line size: 64
L4 cache size: 0
L4 cache line size: 0
```

</details>

**Scenario 2: Legacy Kernel (Fallback path)**

  * **Test Code Part:**
<details>

```
        // if (ret == 0) {
        if (false) {
            uint64_t v = requests[0].value;
            // Update V support from hwprobe if present
            if (v & RISCV_HWPROBE_IMA_V) hwcapFeatures |= static_cast<uint64_t>(RISCVExtension::V);
            
            // Detect Z-extensions using the table
            for (const auto& entry : getExtensionTable()) {
                if (v & entry.hwprobe_bit) {
                    hwcapFeatures |= static_cast<uint64_t>(entry.id);
                    std::cout << "[Xbyak_riscv DEBUG] Detected via hwprobe: " << entry.name << std::endl;
                }
            }
        } else {
            // 3. Fallback: If hwprobe failed (Kernel < 6.4), use procfs
            std::cout << "[Xbyak_riscv DEBUG] riscv_hwprobe syscall failed (ret=" << ret << "). Falling back to legacy AT_HWCAP/procfs path." << std::endl;
            // We only try this if the base Vector extension is present.
            if (hasExtension(RISCVExtension::V)) {
                std::cout << "[Xbyak_riscv DEBUG] Vector extension found via HWCAP. Parsing /proc/cpuinfo for sub-extensions." << std::endl;
                detect_extensions_procfs();
            }
        }
```

</details>

  * **Log:**

<details>

```
[xiazz@PolyOS-Server xbyak_riscv]$ clang++ -I. sample/cpuinfo.cpp -o cpuinfo
[xiazz@PolyOS-Server xbyak_riscv]$ ./cpuinfo 
[Xbyak_riscv DEBUG] riscv_hwprobe syscall failed (ret=0). Falling back to legacy AT_HWCAP/procfs path.
[Xbyak_riscv DEBUG] Vector extension found via HWCAP. Parsing /proc/cpuinfo for sub-extensions.
Number of RISC-V CPU cores: 64
XLEN: 64 bits
VLEN: 128 bits
FLEN: 64 bits

Supported RISC-V extensions:
Has I: 1
Has M: 1
Has A: 1
Has F: 1
Has D: 1
Has C: 1
Has V: 1
Has Zvfh: 1
Has Zvbb: 0
Has Zvbc: 0
Has Zvkg: 0

Cache info:
L1 cache size: 65536
L1 cache line size: 64
L2 cache size: 2097152
L2 cache line size: 64
L3 cache size: 67108864
L3 cache line size: 64
L4 cache size: 0
L4 cache line size: 0
```

</details>

**Scenario 3: make test**
<details>

```
[xiazz@PolyOS-Server xbyak_riscv]$ env CXX="g++ -std=c++11 --pedantic -fmax-errors=20" AS="as" OBJDUMP="objdump" make test
make clean
make[1]: 进入目录“/home/xiazz/xbyak_riscv”
make -C sample clean
make[2]: 进入目录“/home/xiazz/xbyak_riscv/sample”
rm -rf *.o *.exe
make[2]: 离开目录“/home/xiazz/xbyak_riscv/sample”
make -C test clean
make[2]: 进入目录“/home/xiazz/xbyak_riscv/test”
rm -rf generated.cpp a.out *.o *.txt *.s *.o *.exe
make[2]: 离开目录“/home/xiazz/xbyak_riscv/test”
make[1]: 离开目录“/home/xiazz/xbyak_riscv”
make -C gen
make[1]: 进入目录“/home/xiazz/xbyak_riscv/gen”
make[1]: 对“all”无需做任何事。
make[1]: 离开目录“/home/xiazz/xbyak_riscv/gen”
make -C test test
make[1]: 进入目录“/home/xiazz/xbyak_riscv/test”
g++ -std=c++11 --pedantic -fmax-errors=20 -o jmp_test.exe jmp_test.cpp -Wall -Wextra -Wsuggest-override -I ../ -I ./
g++ -std=c++11 --pedantic -fmax-errors=20 -o misc_test.exe misc_test.cpp -Wall -Wextra -Wsuggest-override -I ../ -I ./
./jmp_test.exe
ctest:module=putL
ctest:name=jmp_test, module=1, total=6, ok=6, ng=0, exception=0
./misc_test.exe
ctest:module=align
addr1=0x7fff86971004
addr2=0x7fff86971010
addr3=0x7fff86971018
addr4=0x7fff86971020
addr5=0x7fff86971030
addr6=0x7fff86971030
ctest:name=misc_test, module=1, total=6, ok=6, ng=0, exception=0
./test.sh
test
as -c -o generated.o generated.s -march=rv64imafdqv_zifencei
make[1]: 离开目录“/home/xiazz/xbyak_riscv/test”
make -C test test_svc
make[1]: 进入目录“/home/xiazz/xbyak_riscv/test”
./test.sh svc
svc test
as -c -o generated.o generated.s -march=rv64imafdqvc_zifencei
make[1]: 离开目录“/home/xiazz/xbyak_riscv/test”
```

</details>