### PR TITLE
feat: support riscv D standard extention

### DIFF
--- a/gen/gen.py
+++ b/gen/gen.py
@@ -242,7 +242,7 @@ for (code, name, imm) in tbl:
   else:
     print(f'void {name}(const Reg& rd, CSR csr, uint32_t imm) {{ opCSR({hex(code)}, csr, imm, rd); }}')
 
-# encode RV32F, RV64F instructions with OP-FP opcode
+# encode RV32F, RV64F, RV32D, RV64D instructions with OP-FP opcode
 tbl = [
   # RV32_F extension
   (0b00000000000000000000000001010011, 'rs2', 'rm', 'fadd_s'),
@@ -270,6 +270,34 @@ tbl = [
   (0b11000000001100000000000001010011, '-', 'rm', 'fcvt_lu_s'),
   (0b11010000001000000000000001010011, '-', 'rm', 'fcvt_s_l'),
   (0b11010000001100000000000001010011, '-', 'rm', 'fcvt_s_lu'),
+  # RV32_D extension
+  (0b00000010000000000000000001010011, 'rs2', 'rm', 'fadd_d'),
+  (0b00001010000000000000000001010011, 'rs2', 'rm', 'fsub_d'),
+  (0b00010010000000000000000001010011, 'rs2', 'rm', 'fmul_d'),
+  (0b00011010000000000000000001010011, 'rs2', 'rm', 'fdiv_d'),
+  (0b01011010000000000000000001010011, '-', 'rm', 'fsqrt_d'),
+  (0b00100010000000000000000001010011, 'rs2', '-', 'fsgnj_d'),
+  (0b00100010000000000001000001010011, 'rs2', '-', 'fsgnjn_d'),
+  (0b00100010000000000010000001010011, 'rs2', '-', 'fsgnjx_d'),
+  (0b00101010000000000000000001010011, 'rs2', '-', 'fmin_d'),
+  (0b00101010000000000001000001010011, 'rs2', '-', 'fmax_d'),
+  (0b01000000000100000000000001010011, '-', 'rm', 'fcvt_s_d'),
+  (0b01000010000000000000000001010011, '-', 'rm', 'fcvt_d_s'),
+  (0b10100010000000000010000001010011, 'rs2', '-', 'feq_d'),
+  (0b10100010000000000001000001010011, 'rs2', '-', 'flt_d'),
+  (0b10100010000000000000000001010011, 'rs2', '-', 'fle_d'),
+  (0b11100010000000000001000001010011, '-', '-', 'fclass_d'),
+  (0b11000010000000000000000001010011, '-', 'rm', 'fcvt_w_d'),
+  (0b11000010000100000000000001010011, '-', 'rm', 'fcvt_wu_d'),
+  (0b11010010000000000000000001010011, '-', 'rm', 'fcvt_d_w'),
+  (0b11010010000100000000000001010011, '-', 'rm', 'fcvt_d_wu'),
+  # RV64_D extension
+  (0b11000010001000000000000001010011, '-', 'rm', 'fcvt_l_d'),
+  (0b11000010001100000000000001010011, '-', 'rm', 'fcvt_lu_d'),
+  (0b11100010000000000000000001010011, '-', '-', 'fmv_x_d'),
+  (0b11010010001000000000000001010011, '-', 'rm', 'fcvt_d_l'),
+  (0b11010010001100000000000001010011, '-', 'rm', 'fcvt_d_lu'),
+  (0b11110010000000000000000001010011, '-', '-', 'fmv_d_x'),
   # RV32_Zfh extension
   (0b00000100000000000000000001010011, 'rs2', 'rm', 'fadd_h'),
   (0b11100100000000000001000001010011, '-', '-', 'fclass_h'),
@@ -310,10 +338,12 @@ def opFP(baseValue, rs2, rm, name):
   rd_type, rs1_type = 'FReg', 'FReg'
   if any([name.startswith(p) for p in ['fcvt', 'fmv', 'fclass']]):
     if name not in ['fcvt_s_w', 'fcvt_s_wu', 'fcvt_s_l', 'fcvt_s_lu', 'fmv_w_x',
+                    'fcvt_d_s', 'fcvt_s_d', 'fcvt_d_w', 'fcvt_d_wu', 'fcvt_d_l', 'fcvt_d_lu', 'fmv_d_x',
                     'fcvt_h_w', 'fcvt_h_wu', 'fcvt_h_l', 'fcvt_h_lu', 'fmv_h_x']:
       rd_type = 'Reg'
 
     if name not in ['fcvt_w_s', 'fcvt_wu_s', 'fcvt_l_s', 'fcvt_lu_s', 'fmv_x_w', 'fclass_s',
+                                'fcvt_d_s', 'fcvt_s_d', 'fcvt_w_d', 'fcvt_wu_d', 'fcvt_l_d', 'fcvt_lu_d', 'fmv_x_d', 'fclass_d',
                                 'fcvt_w_h', 'fcvt_wu_h', 'fcvt_l_h', 'fcvt_lu_h', 'fmv_x_h', 'fclass_h']:
       rs1_type = 'Reg'
 
@@ -354,6 +384,11 @@ void fmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, 
 void fmsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x4000047, rs3, rs2, rs1, rm, rd); }
 void fnmsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x400004b, rs3, rs2, rs1, rm, rd); }
 void fnmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x400004f, rs3, rs2, rs1, rm, rd); }
+
+void fmadd_d(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x2000043, rs3, rs2, rs1, rm, rd); }
+void fmsub_d(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x2000047, rs3, rs2, rs1, rm, rd); }
+void fnmsub_d(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x200004b, rs3, rs2, rs1, rm, rd); }
+void fnmadd_d(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x200004f, rs3, rs2, rs1, rm, rd); }
 ''')
 
 # encode LOAD-FP, STORE-FP instructions

--- a/xbyak_riscv/xbyak_riscv_mnemonic.hpp
+++ b/xbyak_riscv/xbyak_riscv_mnemonic.hpp
@@ -131,6 +131,32 @@ void fcvt_l_s(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc0200053, 
 void fcvt_lu_s(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc0300053, 0, rs1, rm, rd); }
 void fcvt_s_l(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd0200053, 0, rs1, rm, rd); }
 void fcvt_s_lu(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd0300053, 0, rs1, rm, rd); }
+void fadd_d(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x2000053, rs2, rs1, rm, rd); }
+void fsub_d(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0xa000053, rs2, rs1, rm, rd); }
+void fmul_d(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x12000053, rs2, rs1, rm, rd); }
+void fdiv_d(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x1a000053, rs2, rs1, rm, rd); }
+void fsqrt_d(const FReg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0x5a000053, 0, rs1, rm, rd); }
+void fsgnj_d(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x22000053, rs2, rs1, 0, rd); }
+void fsgnjn_d(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x22001053, rs2, rs1, 0, rd); }
+void fsgnjx_d(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x22002053, rs2, rs1, 0, rd); }
+void fmin_d(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x2a000053, rs2, rs1, 0, rd); }
+void fmax_d(const FReg& rd, const FReg& rs1, const FReg& rs2) { opFP(0x2a001053, rs2, rs1, 0, rd); }
+void fcvt_s_d(const FReg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0x40100053, 0, rs1, rm, rd); }
+void fcvt_d_s(const FReg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0x42000053, 0, rs1, rm, rd); }
+void feq_d(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa2002053, rs2, rs1, 0, rd); }
+void flt_d(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa2001053, rs2, rs1, 0, rd); }
+void fle_d(const Reg& rd, const FReg& rs1, const FReg& rs2) { opFP(0xa2000053, rs2, rs1, 0, rd); }
+void fclass_d(const Reg& rd, const FReg& rs1) { opFP(0xe2001053, 0, rs1, 0, rd); }
+void fcvt_w_d(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc2000053, 0, rs1, rm, rd); }
+void fcvt_wu_d(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc2100053, 0, rs1, rm, rd); }
+void fcvt_d_w(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd2000053, 0, rs1, rm, rd); }
+void fcvt_d_wu(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd2100053, 0, rs1, rm, rd); }
+void fcvt_l_d(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc2200053, 0, rs1, rm, rd); }
+void fcvt_lu_d(const Reg& rd, const FReg& rs1, RM rm=RM::dyn) { opFP(0xc2300053, 0, rs1, rm, rd); }
+void fmv_x_d(const Reg& rd, const FReg& rs1) { opFP(0xe2000053, 0, rs1, 0, rd); }
+void fcvt_d_l(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd2200053, 0, rs1, rm, rd); }
+void fcvt_d_lu(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd2300053, 0, rs1, rm, rd); }
+void fmv_d_x(const FReg& rd, const Reg& rs1) { opFP(0xf2000053, 0, rs1, 0, rd); }
 void fadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x4000053, rs2, rs1, rm, rd); }
 void fclass_h(const Reg& rd, const FReg& rs1) { opFP(0xe4001053, 0, rs1, 0, rd); }
 void fcvt_h_s(const Reg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0x44000053, 0, rs1, rm, rd); }
@@ -167,6 +193,11 @@ void fmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, 
 void fmsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x4000047, rs3, rs2, rs1, rm, rd); }
 void fnmsub_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x400004b, rs3, rs2, rs1, rm, rd); }
 void fnmadd_h(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x400004f, rs3, rs2, rs1, rm, rd); }
+
+void fmadd_d(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x2000043, rs3, rs2, rs1, rm, rd); }
+void fmsub_d(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x2000047, rs3, rs2, rs1, rm, rd); }
+void fnmsub_d(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x200004b, rs3, rs2, rs1, rm, rd); }
+void fnmadd_d(const FReg& rd, const FReg& rs1, const FReg& rs2, const FReg& rs3, RM rm=RM::dyn) { opR4(0x200004f, rs3, rs2, rs1, rm, rd); }
 
 
 void flq(const FReg& rd, const Reg& rs1, int32_t imm12 = 0) { opLoadFP(0x4007, imm12, rs1, rd); }


### PR DESCRIPTION
## Summary

Add RISC-V D extension mnemonic support for double-precision floating-point instructions.

This updates the mnemonic generator so the generated header includes D-extension OP-FP and fused multiply-add/subtract helpers, while keeping `xbyak_riscv_mnemonic.hpp` reproducible from `gen/gen.py`.

## Changes

- Add RV32D OP-FP mnemonics:
  - `fadd_d`, `fsub_d`, `fmul_d`, `fdiv_d`, `fsqrt_d`
  - `fsgnj_d`, `fsgnjn_d`, `fsgnjx_d`
  - `fmin_d`, `fmax_d`
  - `fcvt_s_d`, `fcvt_d_s`
  - `feq_d`, `flt_d`, `fle_d`
  - `fclass_d`
  - `fcvt_w_d`, `fcvt_wu_d`, `fcvt_d_w`, `fcvt_d_wu`

- Add RV64D OP-FP mnemonics:
  - `fcvt_l_d`, `fcvt_lu_d`
  - `fmv_x_d`
  - `fcvt_d_l`, `fcvt_d_lu`
  - `fmv_d_x`

- Add D-extension R4 fused operation mnemonics:
  - `fmadd_d`
  - `fmsub_d`
  - `fnmsub_d`
  - `fnmadd_d`

- Update OP-FP generator type inference so D conversion, move, and class instructions use the correct `Reg` vs `FReg` argument types.

- Regenerate `xbyak_riscv/xbyak_riscv_mnemonic.hpp` from `gen/gen.py`.

## Validation

- Regenerated mnemonic header:

- Ran project tests with local RISC-V GNU tools:

- Cross-checked D instruction encodings against GNU assembler/objdump output:
  - 26 OP-FP D instructions
  - 4 R4 D fused instructions
  - `fld` / `fsd`

  All 32 checked encodings matched GNU assembler output.

## Notes

`fld` and `fsd` were already present in the load/store FP section and are unchanged:

- `fld`: `opLoadFP(0x3007, ...)`
- `fsd`: `opStoreFP(0x3027, ...)`
