### PR TITLE
Add RISC-V B extension mnemonic support

### DIFF
--- a/gen/gen.py
+++ b/gen/gen.py
@@ -242,6 +242,79 @@ for (code, name, imm) in tbl:
   else:
     print(f'void {name}(const Reg& rd, CSR csr, uint32_t imm) {{ opCSR({hex(code)}, csr, imm, rd); }}')
 
+# encode Zba/Zbb/Zbc/Zbs scalar bit-manipulation instructions
+def opBitmanipR(funct7, funct3, opcode, name):
+  print(f'void {name}(const Reg& rd, const Reg& rs1, const Reg& rs2) {{ Rtype({hex(opcode)}, {funct3}, {hex(funct7)}, rd, rs1, rs2); }}')
+
+def opBitmanipI(imm12, funct3, opcode, name):
+  print(f'void {name}(const Reg& rd, const Reg& rs1) {{ Itype({hex(opcode)}, {funct3}, rd, rs1, {hex(imm12)}); }}')
+
+def opBitmanipShift(funct7, funct3, opcode, name, range = 0):
+  if range == 0:
+    print(f'void {name}(const Reg& rd, const Reg& rs1, uint32_t shamt) {{ opShift({hex(funct7)}, {funct3}, {hex(opcode)}, rd, rs1, shamt); }}')
+  else:
+    print(f'void {name}(const Reg& rd, const Reg& rs1, uint32_t shamt) {{ opShift({hex(funct7)}, {funct3}, {hex(opcode)}, rd, rs1, shamt, {range}); }}')
+
+tbl = [
+  (0x10, 0b010, 0x33, 'sh1add'),
+  (0x10, 0b100, 0x33, 'sh2add'),
+  (0x10, 0b110, 0x33, 'sh3add'),
+  (0x04, 0b000, 0x3b, 'add_uw'),
+  (0x10, 0b010, 0x3b, 'sh1add_uw'),
+  (0x10, 0b100, 0x3b, 'sh2add_uw'),
+  (0x10, 0b110, 0x3b, 'sh3add_uw'),
+  (0x20, 0b111, 0x33, 'andn'),
+  (0x20, 0b110, 0x33, 'orn'),
+  (0x20, 0b100, 0x33, 'xnor'),
+  (0x05, 0b100, 0x33, 'min'),
+  (0x05, 0b101, 0x33, 'minu'),
+  (0x05, 0b110, 0x33, 'max'),
+  (0x05, 0b111, 0x33, 'maxu'),
+  (0x30, 0b001, 0x33, 'rol'),
+  (0x30, 0b101, 0x33, 'ror'),
+  (0x30, 0b001, 0x3b, 'rolw'),
+  (0x30, 0b101, 0x3b, 'rorw'),
+  (0x05, 0b001, 0x33, 'clmul'),
+  (0x05, 0b010, 0x33, 'clmulr'),
+  (0x05, 0b011, 0x33, 'clmulh'),
+  (0x24, 0b001, 0x33, 'bclr'),
+  (0x24, 0b101, 0x33, 'bext'),
+  (0x34, 0b001, 0x33, 'binv'),
+  (0x14, 0b001, 0x33, 'bset'),
+]
+for (funct7, funct3, opcode, name) in tbl:
+  opBitmanipR(funct7, funct3, opcode, name)
+
+tbl = [
+  (0x600, 0b001, 0x13, 'clz'),
+  (0x601, 0b001, 0x13, 'ctz'),
+  (0x602, 0b001, 0x13, 'cpop'),
+  (0x600, 0b001, 0x1b, 'clzw'),
+  (0x601, 0b001, 0x1b, 'ctzw'),
+  (0x602, 0b001, 0x1b, 'cpopw'),
+  (0x604, 0b001, 0x13, 'sext_b'),
+  (0x605, 0b001, 0x13, 'sext_h'),
+  (0x287, 0b101, 0x13, 'orc_b'),
+]
+for (imm12, funct3, opcode, name) in tbl:
+  opBitmanipI(imm12, funct3, opcode, name)
+
+print('void rev8(const Reg& rd, const Reg& rs1) { Itype(0x13, 5, rd, rs1, isRV32_ ? 0x698 : 0x6b8); }')
+print('void zext_h(const Reg& rd, const Reg& rs) { Rtype(isRV32_ ? 0x33 : 0x3b, 4, 0x04, rd, rs, x0); }')
+print('void zext_w(const Reg& rd, const Reg& rs) { add_uw(rd, rs, x0); }')
+
+tbl = [
+  (0x30, 0b101, 0x13, 'rori', 0),
+  (0x30, 0b101, 0x1b, 'roriw', 5),
+  (0x04, 0b001, 0x1b, 'slli_uw', 6),
+  (0x24, 0b001, 0x13, 'bclri', 0),
+  (0x24, 0b101, 0x13, 'bexti', 0),
+  (0x34, 0b001, 0x13, 'binvi', 0),
+  (0x14, 0b001, 0x13, 'bseti', 0),
+]
+for (funct7, funct3, opcode, name, range) in tbl:
+  opBitmanipShift(funct7, funct3, opcode, name, range)
+
 # encode RV32F, RV64F, RV32D, RV64D instructions with OP-FP opcode
 tbl = [
   # RV32_F extension
@@ -428,12 +501,8 @@ void mv(const Reg& rd, const Reg& rs) { addi(rd, rs, 0); }
 void not_(const Reg& rd, const Reg& rs) { xori(rd, rs, -1); }
 void neg(const Reg& rd, const Reg& rs) { sub(rd, x0, rs); }
 void negw(const Reg& rd, const Reg& rs) { subw(rd, x0, rs); }
-void sext_b(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 8); srai(rd, rd, XLEN_ - 8); }
-void sext_h(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 16); srai(rd, rd, XLEN_ - 16); }
 void sext_w(const Reg& rd, const Reg& rs) { addiw(rd, rs, 0); }
 void zext_b(const Reg& rd, const Reg& rs) { andi(rd, rs, 255); }
-void zext_h(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 16); srli(rd, rd, XLEN_ - 16); }
-void zext_w(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 32); srli(rd, rd, XLEN_ - 32); }
 void seqz(const Reg& rd, const Reg& rs) { sltiu(rd, rs, 1); }
 void snez(const Reg& rd, const Reg& rs) { sltu(rd, x0, rs); }
 void sltz(const Reg& rd, const Reg& rs) { slt(rd, rs, x0); }

--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -30,6 +30,10 @@ int main()
     std::cout << "Has C: " <<  cpu.hasExtension(RISCVExtension::C) << std::endl;
     std::cout << "Has V: " <<  cpu.hasExtension(RISCVExtension::V) << std::endl;
 
+    std::cout << "Has Zba: " <<  cpu.hasExtension(RISCVExtension::Zba) << std::endl;
+    std::cout << "Has Zbb: " <<  cpu.hasExtension(RISCVExtension::Zbb) << std::endl;
+    std::cout << "Has Zbc: " <<  cpu.hasExtension(RISCVExtension::Zbc) << std::endl;
+    std::cout << "Has Zbs: " <<  cpu.hasExtension(RISCVExtension::Zbs) << std::endl;
     std::cout << "Has Zvfh: " <<  cpu.hasExtension(RISCVExtension::Zvfh) << std::endl;
     std::cout << "Has Zvbb: " <<  cpu.hasExtension(RISCVExtension::Zvbb) << std::endl;
     std::cout << "Has Zvbc: " <<  cpu.hasExtension(RISCVExtension::Zvbc) << std::endl;

--- a/test/gen_test.py
+++ b/test/gen_test.py
@@ -230,6 +230,23 @@ def misc():
   ]:
     put('li', f'x2, {v}')
 
+def bitmanip():
+  for op in ['sh1add', 'sh2add', 'sh3add', 'add_uw', 'sh1add_uw', 'sh2add_uw', 'sh3add_uw',
+    'andn', 'orn', 'xnor', 'min', 'minu', 'max', 'maxu', 'rol', 'ror', 'rolw', 'rorw',
+    'clmul', 'clmulr', 'clmulh', 'bclr', 'bext', 'binv', 'bset',
+  ]:
+    putRRR(op)
+
+  for op in ['clz', 'ctz', 'cpop', 'clzw', 'ctzw', 'cpopw', 'sext_b', 'sext_h', 'zext_h', 'zext_w', 'orc_b', 'rev8']:
+    putRR(op)
+
+  for shamt in [0, 1, 31, 32, 63]:
+    for op in ['rori', 'slli_uw', 'bclri', 'bexti', 'binvi', 'bseti']:
+      put(op, f'x1, x2, {shamt}')
+
+  for shamt in [0, 1, 31]:
+    put('roriw', f'x1, x2, {shamt}')
+
 def vec():
   tbl1 = ['vmclr_m', 'vmset_m']
   for op in tbl1:
@@ -293,6 +310,7 @@ def main():
 
   csr()
   fpu()
+  bitmanip()
   misc()
   vec()
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -18,7 +18,7 @@ vec)
   ;;
 esac
 
-ASFLAGS+="_zifencei"
+ASFLAGS+="_zba_zbb_zbc_zbs_zifencei"
 
 CXX=${CXX:-g++}
 AS=${AS:-riscv64-linux-gnu-as}

--- a/xbyak_riscv/xbyak_riscv_mnemonic.hpp
+++ b/xbyak_riscv/xbyak_riscv_mnemonic.hpp
@@ -107,6 +107,50 @@ void csrrc(const Reg& rd, CSR csr, const Reg& rs1) { opCSR(0x3073, csr, rs1, rd)
 void csrrwi(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x5073, csr, imm, rd); }
 void csrrsi(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x6073, csr, imm, rd); }
 void csrrci(const Reg& rd, CSR csr, uint32_t imm) { opCSR(0x7073, csr, imm, rd); }
+void sh1add(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 2, 0x10, rd, rs1, rs2); }
+void sh2add(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 4, 0x10, rd, rs1, rs2); }
+void sh3add(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 6, 0x10, rd, rs1, rs2); }
+void add_uw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 0, 0x4, rd, rs1, rs2); }
+void sh1add_uw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 2, 0x10, rd, rs1, rs2); }
+void sh2add_uw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 4, 0x10, rd, rs1, rs2); }
+void sh3add_uw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 6, 0x10, rd, rs1, rs2); }
+void andn(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 7, 0x20, rd, rs1, rs2); }
+void orn(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 6, 0x20, rd, rs1, rs2); }
+void xnor(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 4, 0x20, rd, rs1, rs2); }
+void min(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 4, 0x5, rd, rs1, rs2); }
+void minu(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 5, 0x5, rd, rs1, rs2); }
+void max(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 6, 0x5, rd, rs1, rs2); }
+void maxu(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 7, 0x5, rd, rs1, rs2); }
+void rol(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x30, rd, rs1, rs2); }
+void ror(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 5, 0x30, rd, rs1, rs2); }
+void rolw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 1, 0x30, rd, rs1, rs2); }
+void rorw(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x3b, 5, 0x30, rd, rs1, rs2); }
+void clmul(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x5, rd, rs1, rs2); }
+void clmulr(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 2, 0x5, rd, rs1, rs2); }
+void clmulh(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 3, 0x5, rd, rs1, rs2); }
+void bclr(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x24, rd, rs1, rs2); }
+void bext(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 5, 0x24, rd, rs1, rs2); }
+void binv(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x34, rd, rs1, rs2); }
+void bset(const Reg& rd, const Reg& rs1, const Reg& rs2) { Rtype(0x33, 1, 0x14, rd, rs1, rs2); }
+void clz(const Reg& rd, const Reg& rs1) { Itype(0x13, 1, rd, rs1, 0x600); }
+void ctz(const Reg& rd, const Reg& rs1) { Itype(0x13, 1, rd, rs1, 0x601); }
+void cpop(const Reg& rd, const Reg& rs1) { Itype(0x13, 1, rd, rs1, 0x602); }
+void clzw(const Reg& rd, const Reg& rs1) { Itype(0x1b, 1, rd, rs1, 0x600); }
+void ctzw(const Reg& rd, const Reg& rs1) { Itype(0x1b, 1, rd, rs1, 0x601); }
+void cpopw(const Reg& rd, const Reg& rs1) { Itype(0x1b, 1, rd, rs1, 0x602); }
+void sext_b(const Reg& rd, const Reg& rs1) { Itype(0x13, 1, rd, rs1, 0x604); }
+void sext_h(const Reg& rd, const Reg& rs1) { Itype(0x13, 1, rd, rs1, 0x605); }
+void orc_b(const Reg& rd, const Reg& rs1) { Itype(0x13, 5, rd, rs1, 0x287); }
+void rev8(const Reg& rd, const Reg& rs1) { Itype(0x13, 5, rd, rs1, isRV32_ ? 0x698 : 0x6b8); }
+void zext_h(const Reg& rd, const Reg& rs) { Rtype(isRV32_ ? 0x33 : 0x3b, 4, 0x04, rd, rs, x0); }
+void zext_w(const Reg& rd, const Reg& rs) { add_uw(rd, rs, x0); }
+void rori(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x30, 5, 0x13, rd, rs1, shamt); }
+void roriw(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x30, 5, 0x1b, rd, rs1, shamt, 5); }
+void slli_uw(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x4, 1, 0x1b, rd, rs1, shamt, 6); }
+void bclri(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x24, 1, 0x13, rd, rs1, shamt); }
+void bexti(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x24, 5, 0x13, rd, rs1, shamt); }
+void binvi(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x34, 1, 0x13, rd, rs1, shamt); }
+void bseti(const Reg& rd, const Reg& rs1, uint32_t shamt) { opShift(0x14, 1, 0x13, rd, rs1, shamt); }
 void fadd_s(const FReg& rd, const FReg& rs1, const FReg& rs2, RM rm=RM::dyn) { opFP(0x53, rs2, rs1, rm, rd); }
 void fclass_s(const Reg& rd, const FReg& rs1) { opFP(0xe0001053, 0, rs1, 0, rd); }
 void fcvt_s_w(const FReg& rd, const Reg& rs1, RM rm=RM::dyn) { opFP(0xd0000053, 0, rs1, rm, rd); }
@@ -233,12 +277,8 @@ void mv(const Reg& rd, const Reg& rs) { addi(rd, rs, 0); }
 void not_(const Reg& rd, const Reg& rs) { xori(rd, rs, -1); }
 void neg(const Reg& rd, const Reg& rs) { sub(rd, x0, rs); }
 void negw(const Reg& rd, const Reg& rs) { subw(rd, x0, rs); }
-void sext_b(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 8); srai(rd, rd, XLEN_ - 8); }
-void sext_h(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 16); srai(rd, rd, XLEN_ - 16); }
 void sext_w(const Reg& rd, const Reg& rs) { addiw(rd, rs, 0); }
 void zext_b(const Reg& rd, const Reg& rs) { andi(rd, rs, 255); }
-void zext_h(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 16); srli(rd, rd, XLEN_ - 16); }
-void zext_w(const Reg& rd, const Reg& rs) { slli(rd, rs, XLEN_ - 32); srli(rd, rd, XLEN_ - 32); }
 void seqz(const Reg& rd, const Reg& rs) { sltiu(rd, rs, 1); }
 void snez(const Reg& rd, const Reg& rs) { sltu(rd, x0, rs); }
 void sltz(const Reg& rd, const Reg& rs) { slt(rd, rs, x0); }

--- a/xbyak_riscv/xbyak_riscv_util.hpp
+++ b/xbyak_riscv/xbyak_riscv_util.hpp
@@ -67,6 +67,22 @@ namespace Xbyak_riscv {
 #define RISCV_HWPROBE_IMA_V (1ULL << 2)
 #endif
 
+#ifndef RISCV_HWPROBE_EXT_ZBA
+#define RISCV_HWPROBE_EXT_ZBA (1ULL << 3)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZBB
+#define RISCV_HWPROBE_EXT_ZBB (1ULL << 4)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZBS
+#define RISCV_HWPROBE_EXT_ZBS (1ULL << 5)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZBC
+#define RISCV_HWPROBE_EXT_ZBC (1ULL << 7)
+#endif
+
 #ifndef RISCV_HWPROBE_EXT_ZVBB
 #define RISCV_HWPROBE_EXT_ZVBB (1ULL << 17)
 #endif
@@ -109,7 +125,11 @@ enum class RISCVExtension : uint64_t {
     Zvbb = 1ULL << 27,
     Zvbc = 1ULL << 28,
     Zvkg = 1ULL << 29,
-    Zvfbfwma = 1ULL << 30
+    Zvfbfwma = 1ULL << 30,
+    Zba = 1ULL << 31,
+    Zbb = 1ULL << 32,
+    Zbc = 1ULL << 33,
+    Zbs = 1ULL << 34
 };
 
 template <CSR csr>
@@ -171,7 +191,11 @@ public:
                 { RISCVExtension::Zvbb, RISCV_HWPROBE_EXT_ZVBB },
                 { RISCVExtension::Zvbc, RISCV_HWPROBE_EXT_ZVBC },
                 { RISCVExtension::Zvkg, RISCV_HWPROBE_EXT_ZVKG },
-                { RISCVExtension::Zvfbfwma, RISCV_HWPROBE_EXT_ZVFBFWMA }
+                { RISCVExtension::Zvfbfwma, RISCV_HWPROBE_EXT_ZVFBFWMA },
+                { RISCVExtension::Zba, RISCV_HWPROBE_EXT_ZBA },
+                { RISCVExtension::Zbb, RISCV_HWPROBE_EXT_ZBB },
+                { RISCVExtension::Zbc, RISCV_HWPROBE_EXT_ZBC },
+                { RISCVExtension::Zbs, RISCV_HWPROBE_EXT_ZBS }
             };
             for (const auto& entry : table) {
                 if (v & entry.hwprobe_bit) {


### PR DESCRIPTION
## Summary

Add RISC-V scalar B standard extension support for bit-manipulation instructions.

This implements the current standard B grouping as `Zba`, `Zbb`, `Zbc`, and `Zbs`, updates the mnemonic generator so `xbyak_riscv_mnemonic.hpp` remains reproducible from `gen/gen.py`, and adds runtime CPU feature detection for the new scalar bitmanip subextensions.

## Changes

- Add `Zba` address-generation mnemonics:
  - `sh1add`, `sh2add`, `sh3add`
  - `add_uw`, `sh1add_uw`, `sh2add_uw`, `sh3add_uw`, `slli_uw`

- Add `Zbb` basic bit-manipulation mnemonics:
  - `andn`, `orn`, `xnor`
  - `clz`, `ctz`, `cpop`, `clzw`, `ctzw`, `cpopw`
  - `min`, `minu`, `max`, `maxu`
  - `rol`, `ror`, `rori`, `rolw`, `rorw`, `roriw`
  - `orc_b`, `rev8`

- Add `Zbc` carry-less multiplication mnemonics:
  - `clmul`, `clmulh`, `clmulr`

- Add `Zbs` single-bit operation mnemonics:
  - `bclr`, `bext`, `binv`, `bset`
  - `bclri`, `bexti`, `binvi`, `bseti`

- Update overlapping helper mnemonics to use standard B-extension encodings:
  - `sext_b`
  - `sext_h`
  - `zext_h`
  - `zext_w`

- Add `RISCVExtension::Zba`, `RISCVExtension::Zbb`, `RISCVExtension::Zbc`, and `RISCVExtension::Zbs`, and detect them through Linux `riscv_hwprobe` when available.

- Update `sample/cpuinfo.cpp` to print scalar bitmanip extension availability.

- Update tests so GAS uses:
  - `-march=rv64imafdqv_zba_zbb_zbc_zbs_zifencei`

- Regenerate `xbyak_riscv/xbyak_riscv_mnemonic.hpp` from `gen/gen.py`.

## Validation

- Regenerated mnemonic header:
  - `make -C gen`

- Ran project tests with local RISC-V GNU tools:
  - `make -C test test`
  - `make test`

- Verified `sample/cpuinfo.cpp` still compiles with the new extension enum values:
  - `g++ -I. -Wall -Wextra -DXBYAK_RISCV_V -c sample/cpuinfo.cpp -o /tmp/xbyak_riscv_cpuinfo.o`

- Re-ran the GAS/objdump vs Xbyak encoding comparison and saved both outputs:
  - GAS/objdump output: 1589 lines
  - Xbyak output: 1589 lines
  - `diff -urN /tmp/xbyak_b_gas.txt /tmp/xbyak_b_xbyak.txt` produced no differences.