### PR TITLE
add Zvfbfmin bf16 convert mnemonics

### DIFF
--- a/gen/rvv_instr_dict.yaml
+++ b/gen/rvv_instr_dict.yaml
@@ -1003,6 +1003,16 @@ vfncvt_f_f_w:
   - vm
   - vs2
   - vd
+vfncvtbf16_f_f_w:
+  encoding: 010010------11101001-----1010111
+  extension:
+  - rv_zvfbfmin
+  mask: '0xfc0ff07f'
+  match: '0x480e9057'
+  variable_fields:
+  - vm
+  - vs2
+  - vd
 vfncvt_f_x_w:
   encoding: 010010------10011001-----1010111
   extension:
@@ -1417,6 +1427,16 @@ vfwcvt_f_f_v:
   - rv_v
   mask: '0xfc0ff07f'
   match: '0x48061057'
+  variable_fields:
+  - vm
+  - vs2
+  - vd
+vfwcvtbf16_f_f_v:
+  encoding: 010010------01101001-----1010111
+  extension:
+  - rv_zvfbfmin
+  mask: '0xfc0ff07f'
+  match: '0x48069057'
   variable_fields:
   - vm
   - vs2

--- a/xbyak_riscv/xbyak_riscv_v.hpp
+++ b/xbyak_riscv/xbyak_riscv_v.hpp
@@ -58,6 +58,7 @@ void vfmv_f_s(const FReg& rd, const VReg& vs2) { opFVV(0x42001057, 0, vs2, 0, rd
 void vfmv_s_f(const VReg& vd, const FReg& rs1) { opFVF(0x42005057, 0, 0, rs1, vd); }
 void vfmv_v_f(const VReg& vd, const FReg& rs1) { opFVF(0x5e005057, 0, 0, rs1, vd); }
 void vfncvt_f_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480a1057, vm, vs2, 0, vd); }
+void vfncvtbf16_f_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480e9057, vm, vs2, 0, vd); }
 void vfncvt_f_x_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48099057, vm, vs2, 0, vd); }
 void vfncvt_f_xu_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48091057, vm, vs2, 0, vd); }
 void vfncvt_rod_f_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480a9057, vm, vs2, 0, vd); }
@@ -97,6 +98,7 @@ void vfwadd_vv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmas
 void vfwadd_wf(const VReg& vd, const VReg& vs2, const FReg& rs1, VM vm=VM::unmasked) { opFVF(0xd0005057, vm, vs2, rs1, vd); }
 void vfwadd_wv(const VReg& vd, const VReg& vs2, const VReg& vs1, VM vm=VM::unmasked) { opFVV(0xd0001057, vm, vs2, vs1, vd); }
 void vfwcvt_f_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48061057, vm, vs2, 0, vd); }
+void vfwcvtbf16_f_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48069057, vm, vs2, 0, vd); }
 void vfwcvt_f_x_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48059057, vm, vs2, 0, vd); }
 void vfwcvt_f_xu_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48051057, vm, vs2, 0, vd); }
 void vfwcvt_rtz_x_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48079057, vm, vs2, 0, vd); }


### PR DESCRIPTION
## Summary

Adds the two BF16 conversion instructions from the Zvfbfmin extension:

| Mnemonic | Direction | Encoding (match / mask) |
| :--- | :--- | :--- |
| `vfwcvtbf16_f_f_v` | BF16 → FP32 (widening) | 0x48069057 / 0xfc0ff07f |
| `vfncvtbf16_f_f_w` | FP32 → BF16 (narrowing, round-to-nearest-even) | 0x480e9057 / 0xfc0ff07f |

Both are OPFVV (funct6 010010, funct3 001), distinguished by the vfunary selector in vs1 (01101=13 widening, 11101=29 narrowing), per the ratified Zvfbfmin spec. This complements the existing Zvfbfwma vfwmaccbf16 support — Zvfbfwma requires Zvfbfmin, so these two converts complete the BF16 pairing (load/widen, compute in FP32, narrow/store).

## Changes

- gen/rvv_instr_dict.yaml: two new entries (tagged rv_zvfbfmin).
- xbyak_riscv/xbyak_riscv_v.hpp: regenerated via gen_v.py + bin2hex.py (not hand-edited). Diff is +2 lines, 0 deletions in the header, confirming the change is purely additive.

void vfwcvtbf16_f_f_v(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x48069057, vm, vs2, 0, vd); }
void vfncvtbf16_f_f_w(const VReg& vd, const VReg& vs2, VM vm=VM::unmasked) { opFVV(0x480e9057, vm, vs2, 0, vd); }

## Testing

Verified on real hardware (Spacemit X100, riscv64) by JIT-emitting a kernel that uses both instructions and running it under a SIGILL guard:
- No illegal-instruction trap — the encodings are accepted by the hardware.
- vfwcvtbf16.f.f.v (widen) is bit-exact (BF16 is a strict subset of FP32).
- vfncvtbf16.f.f.w (narrow) matches a host round-to-nearest-even reference bit-for-bit, including hard-rounding inputs (e.g. 0.1, π, -2.71828, 1e-5) and BF16 round-trips.